### PR TITLE
Support questions where answers are neither right nor wrong (fill-in interaction)

### DIFF
--- a/styles/fill-in.css
+++ b/styles/fill-in.css
@@ -38,6 +38,10 @@
   border: dashed 1px #8AC062;
 }
 
+.h5p-fill-in-user-response-correct.h5p-fill-in-no-correct {
+  background-color: #186df7;
+}
+
 .h5p-fill-in-user-response-correct:before {
   font-family: 'h5p-reporting-icons';
   content: "\e90c";

--- a/styles/fill-in.css
+++ b/styles/fill-in.css
@@ -40,6 +40,7 @@
 
 .h5p-fill-in-user-response-correct.h5p-fill-in-no-correct {
   background-color: #186df7;
+  border: none;
 }
 
 .h5p-fill-in-user-response-correct:before {

--- a/type-processors/fill-in-processor.class.php
+++ b/type-processors/fill-in-processor.class.php
@@ -39,6 +39,7 @@ class FillInProcessor extends TypeProcessor {
 
     // Process correct responses and user responses patterns
     $processedCRPs     = $this->processCRPs($crp, $caseMatters['nextIndex']);
+
     $processedResponse = $this->processResponse($response);
 
     // Build report from description, correct responses and user responses
@@ -56,7 +57,6 @@ class FillInProcessor extends TypeProcessor {
 
     // Footer only required if there is a correct responses pattern
     $footer = (sizeof($crp) !== 0) ? $this->generateFooter() : '';
-
 
     return $container . $footer;
   }
@@ -205,7 +205,12 @@ class FillInProcessor extends TypeProcessor {
 
     // Return response without markup if answers are neither right nor wrong
     if (sizeof($crp) === 0) {
-      $placeholderReplacements[] = $response[0];
+      foreach($response as $answer) {
+        $placeholderReplacements[] =
+          '<span class="h5p-fill-in-user-response h5p-fill-in-user-response-correct h5p-fill-in-no-correct">' .
+          $answer .
+          '</span>';
+      }
     }
 
     foreach ($crp as $index => $value) {

--- a/type-processors/fill-in-processor.class.php
+++ b/type-processors/fill-in-processor.class.php
@@ -56,7 +56,7 @@ class FillInProcessor extends TypeProcessor {
       '</div>';
 
     // Footer only required if there is a correct responses pattern
-    $footer = (sizeof($crp) !== 0) ? $this->generateFooter() : '';
+    $footer = (isset($crp)) ? $this->generateFooter() : '';
 
     return $container . $footer;
   }
@@ -108,6 +108,10 @@ class FillInProcessor extends TypeProcessor {
 
     // CRPs sorted by placeholder order
     $sortedCRP = array();
+
+    if (!is_array($crp)) {
+      return $sortedCRP;
+    }
 
     foreach ($crp as $crpString) {
 

--- a/type-processors/fill-in-processor.class.php
+++ b/type-processors/fill-in-processor.class.php
@@ -53,7 +53,9 @@ class FillInProcessor extends TypeProcessor {
       '<div class="h5p-reporting-container h5p-fill-in-container">' .
         $header . $report .
       '</div>';
-    $footer = $this->generateFooter();
+
+    // Footer only required if there is a correct responses pattern
+    $footer = (sizeof($crp) !== 0) ? $this->generateFooter() : '';
 
 
     return $container . $footer;
@@ -200,6 +202,11 @@ class FillInProcessor extends TypeProcessor {
    */
   private function getPlaceholderReplacements($crp, $response, $caseSensitive) {
     $placeholderReplacements = array();
+
+    // Return response without markup if answers are neither right nor wrong
+    if (sizeof($crp) === 0) {
+      $placeholderReplacements[] = $response[0];
+    }
 
     foreach ($crp as $index => $value) {
 


### PR DESCRIPTION
The xAPI specification allows questions where answers are neither right nor wrong. In that case, the correct responses pattern is omitted, cmp. https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#correct-responses-pattern Currently, this is interpreted wrong.

With these changes, if the xAPI statement does not contain a correct responses pattern for an xAPI fill-in interaction, it will display the response without marking the fields that were filled in in any way. It will also suppress the footer with the explanations for markings.

The behavior for xAPI fill-in interactions that provide a correct responses pattern is not changed, so existing content types such as the fill in the blanks or mark the words are not affected.