### PR TITLE
Support questions where answers are neither right nor wrong (choice interaction)

### DIFF
--- a/styles/choice.css
+++ b/styles/choice.css
@@ -60,6 +60,10 @@
   border-radius: 5px;
 }
 
+.h5p-choices-user.h5p-choices-answered.h5p-choices-user-correct.h5p-choices-no-correct {
+  background-color: #186df7;
+}
+
 .h5p-choices-user.h5p-choices-answered.h5p-choices-user-correct:before {
   font-family: 'h5p-reporting-icons';
   content: "\e90c";

--- a/styles/choice.css
+++ b/styles/choice.css
@@ -62,6 +62,7 @@
 
 .h5p-choices-user.h5p-choices-answered.h5p-choices-user-correct.h5p-choices-no-correct {
   background-color: #186df7;
+  border: none;
 }
 
 .h5p-choices-user.h5p-choices-answered.h5p-choices-user-correct:before {

--- a/type-processors/choice-processor.class.php
+++ b/type-processors/choice-processor.class.php
@@ -24,7 +24,8 @@ class ChoiceProcessor extends TypeProcessor {
     // We need some style for our report
     $this->setStyle('styles/choice.css');
 
-    $correctAnswers = explode('[,]', $crp[0]);
+    // choice type exercises lack correct reponses pattern if there's no right/wrong answer
+    $correctAnswers = (isset($crp)) ? explode('[,]', $crp[0]) : NULL;
     $responses = explode('[,]', $response);
 
     $headerHtml = $this->generateHeader($description, $scoreSettings);
@@ -77,14 +78,17 @@ class ChoiceProcessor extends TypeProcessor {
    * @return string Table element
    */
   private function generateTable($extras, $correctAnswers, $responses) {
+    $hasNoRightOrWrong = !isset($correctAnswers);
 
     $choices = $extras->choices;
     $tableHeader =
       '<tr class="h5p-choices-table-heading">' .
-        '<td class="h5p-choices-choice">Answers</td>' .
+        '<td class="h5p-choices-choice">Answers</td>';
+    $tableHeader .= ($hasNoRightOrWrong) ?
+        '<td class="h5p-choices-user-answer">Chosen</td>' :
         '<td class="h5p-choices-user-answer">Your Answer</td>' .
-        '<td class="h5p-choices-crp-answer">Correct</td>' .
-      '</tr>';
+        '<td class="h5p-choices-crp-answer">Correct</td>';
+    $tableHeader .= '</tr>';
 
     $rows = '';
     foreach($choices as $choice) {
@@ -97,6 +101,9 @@ class ChoiceProcessor extends TypeProcessor {
       if ($isAnswered) {
         $userClasses .= ' h5p-choices-answered';
       }
+      if ($hasNoRightOrWrong) {
+        $userClasses .= ' h5p-choices-user-correct h5p-choices-no-correct';
+      }
       if ($isCRP) {
         $userClasses .= ' h5p-choices-user-correct';
         $crpClasses .= ' h5p-choices-crp-correct';
@@ -108,10 +115,13 @@ class ChoiceProcessor extends TypeProcessor {
         '</td>' .
         '<td class="h5p-choices-icon-cell">' .
           '<span class="' . $userClasses . '"></span>' .
-        '</td>' .
-        '<td class="h5p-choices-icon-cell">' .
-          '<span class="' . $crpClasses . '"></span>' .
         '</td>';
+      if (!$hasNoRightOrWrong) {
+        $row .=
+          '<td class="h5p-choices-icon-cell">' .
+            '<span class="' . $crpClasses . '"></span>' .
+          '</td>';
+      }
 
       $rows .= '<tr>' . $row . '</tr>';
     }

--- a/type-processors/choice-processor.class.php
+++ b/type-processors/choice-processor.class.php
@@ -93,7 +93,7 @@ class ChoiceProcessor extends TypeProcessor {
     $rows = '';
     foreach($choices as $choice) {
       $choiceID = $choice->id;
-      $isCRP = in_array($choiceID, $correctAnswers);
+      $isCRP = !$hasNoRightOrWrong && in_array($choiceID, $correctAnswers);
       $isAnswered = in_array($choiceID, $responses);
 
       $userClasses = 'h5p-choices-user';


### PR DESCRIPTION
The xAPI specification allows questions where answers are neither right nor wrong. In that case, the correct responses pattern is omitted, cmp. https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#correct-responses-pattern Currently, this is interpreted wrong.

With these changes, if the xAPI statement does not contain a correct responses pattern for an xAPI choice interaction, it will use a blue checkmark for indicating that the answer was given, relabel the "Answers" column to "Chosen" and suppress the "Correct Answers" column.

The behavior for xAPI choice interactions that provide a correct responses pattern is not changed, so existing content types such as the multiple choice quiz are not affected.